### PR TITLE
Add option showSummary

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ For example, create a `jest.config.js` file containing:
 ```javascript
 module.exports = {
   reporters: [
+    "default",
     ['jest-slow-test-reporter', {
       "numTests": 8, 
       "warnOnSlowerThan": 300, 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Slow test reporter for jest
 
-No dependencies, no interactive shell needed.  Prints out the slowest 10 tests in your app.  Can also print warnings when a test exceeds X ms.
+No dependencies, no interactive shell needed.  Prints out the slowest numTests tests in your app.  Can also print warnings when a test exceeds warnOnSlowerThan ms.
 
 ## Installation
 
@@ -19,13 +19,18 @@ For example, create a `jest.config.js` file containing:
 
 ```javascript
 module.exports = {
-  verbose: false,
   reporters: [
-    ['jest-slow-test-reporter', {"numTests": 8, "warnOnSlowerThan": 300, "color": true}]
+    ['jest-slow-test-reporter', {
+      "numTests": 8, 
+      "warnOnSlowerThan": 300, 
+      "color": true,
+      "showSummary": false
+    }]
   ]
 };
 ```
 
-numTests controls how many slow tests to print.
-warnOnSlowerThan will warn when a test exceeds this time in milliseconds.
-color will make the warnOnSlowerThan warning messages print in red
+- numTests controls how many slow tests to print.
+- warnOnSlowerThan will warn when a test exceeds this time in milliseconds.
+- color will make the warnOnSlowerThan warning messages print in red
+- showSummary (default true) will disable the summary if false

--- a/jest-slow-test-reporter.js
+++ b/jest-slow-test-reporter.js
@@ -6,6 +6,8 @@ class JestSlowTestReporter {
     }
 
     onRunComplete() {
+        if (this._options.showSummary == false) return;
+        
         console.log();
 
         this._slowTests.sort(function(a, b) {


### PR DESCRIPTION
I use jest-slow-test-reporter to warn me on all tests slower than 300 ms. I don't want a summary, especially one that always outputs the same number of test reports each time. So, why not create an option to disable the summary all together!